### PR TITLE
Regenerate patch files on cache clear

### DIFF
--- a/patchwork.php
+++ b/patchwork.php
@@ -195,8 +195,14 @@ function patchwork__patch_file($override) {
     . '.php');
 
   // Do we need to (re)create the patched file?
-  $create_patch = (!file_exists($patched_version)
-    || (filemtime($original_file) > filemtime($patched_version)));
+  $create_patch = (
+    // No file, we need to create
+    !file_exists($patched_version)
+    // Original core file has been updated, regenerate patch
+    || (filemtime($original_file) > filemtime($patched_version))
+    // Caches have been cleared. Regenerate patches
+    || (filemtime(\Civi::paths()->getPath("[civicrm.compile]/.")) > filemtime($patched_version))
+  );
 
   // Default action is to include original file.
   $file_to_include = $original_file;


### PR DESCRIPTION
1. If the patch doesn't exist we generate it.
2. If the core file is updated we regenerate it.
3. If the extension that requires patchwork is updated we don't regenerate patches.

This "fixes" 3 so that a cache clear in CiviCRM will force regeneration of patch files. This is useful because it ensures that the client site is using the latest version of patched files if you issue them with an updated extension as they are usually familiar with "clearing caches". The alternative is to ask them to manually delete the contents of the patchwork directory which may or may not be easy...