### PR TITLE
V1.3 adds tests and delete patches methods

### DIFF
--- a/Civi/Patchwork.php
+++ b/Civi/Patchwork.php
@@ -1,0 +1,182 @@
+<?php
+namespace Civi;
+
+use Civi;
+use Civi\Patchwork\Worker;
+use Civi\Patchwork\CannotIncludeException;
+use Civi\Patchwork\PatchingFailedException;
+
+class Patchwork {
+
+  /**
+   * @var string
+   */
+  protected string $patchesDir;
+
+  /**
+   * @var Patchwork Holds singleton.
+   */
+  protected Patchwork $singleton;
+
+  /**
+   * Main calling point; all exceptions logged as critical messages, but
+   * execution will continue.
+   */
+  public static function includeOnce(string $corePath) {
+    try {
+      // Check $corePath is ok and we have what we need to continue.
+      $p = new Worker($corePath);
+      // Make patch as necessary
+      $p->ensurePatchApplied();
+      // If that worked, include the patched version.
+      include_once $p->getPatchedPath();
+    }
+    catch (CannotIncludeException $e) {
+      Civi::log()->critical("Patchwork CannotIncludeException, code may be missing ({$corePath}): " . $e->getMessage());
+    }
+    catch (PatchingFailedException $e) {
+      Civi::log()->critical("Patchwork PatchingFailedException, using original unpatched code ({$corePath}): " . $e->getMessage());
+      include_once $p->getOriginalPath();
+    }
+    catch (\Exception $e) {
+      Civi::log()->critical("Patchwork unhandled exception: " . get_class($e) . " ({$corePath}): " . $e->getMessage());
+      throw $e;
+    }
+  }
+
+  public static function singleton() :Patchwork {
+    if (!isset(static::$singleton)) {
+      static::$singleton = new static();
+    }
+    return static::$singleton;
+  }
+
+  public function __construct() {
+
+  }
+  /**
+   * Prepare the directory for the patched files, return the path or throw a PatchingFailedException.
+   */
+  public function prepareDir() :string {
+    // Need to create patches dir.
+    // Attempt, but don't abort (i.e. throw exception) if it fails.
+    $patchesDir = $this->getPatchesDir();
+    $outcome = \CRM_Utils_File::createDir($patchesDir, FALSE);
+    if ($outcome === FALSE) {
+      // Creation failed.
+      throw new PatchingFailedException("Patchwork failed to create/prepare the patches directory at '{$patchesDir}'");
+    }
+    // Otherwise (TRUE|NULL), it's fine.
+    return $patchesDir;
+  }
+  /**
+   * Returns the path to the patches dir.
+   */
+  public function getPatchesDir() :string {
+    if (!isset($this->patchesDir)) {
+      $this->patchesDir = Civi::paths()->getPath('[civicrm.files]/patchwork/');
+    }
+    return $this->patchesDir;
+  }
+  /**
+   * Delete all patched files.
+   *
+   * @return int the number of deleted patch files (may be 0).
+   * @throw RuntimeException if a deletion fails.
+   */
+  public function deletePatches() :int {
+    $patchesDir = $this->prepareDir();
+
+    $dir = new \DirectoryIterator($patchesDir);
+    $errors = [];
+    $successes = 0;
+    foreach ($dir as $fileinfo) {
+      if (!$fileinfo->isDot()) {
+        if (preg_match('/^[0-9a-f]{40}\.php$/', $fileinfo->getFilename())) {
+          // Looks like a patch file.
+          if (unlink($fileinfo->getPathname())) {
+            $successes++;
+          }
+          else {
+            $errors[] = $fileinfo->getFilename();
+          }
+        }
+      }
+    }
+    if ($errors) {
+      throw new \RuntimeException("Patchwork failed to delete the following patches in '$patchesDir' (check permissions?): " . implode(' ', $errors));
+    }
+    return $successes;
+  }
+  /**
+   * Delete the patch file for a given core path.
+   *
+   * @param string the core file, e.g. /CRM/Core/Activity.php
+   *
+   * @throw RuntimeException if a deletion fails.
+   */
+  public function deletePatch(string $corePath) {
+    $patchesDir = $this->getPatchesDir();
+
+    $patchedPath = $patchesDir . '/' . sha1($corePath . CIVICRM_SITE_KEY) . '.php';
+    if (file_exists($patchedPath)) {
+      if (!unlink($patchedPath)) {
+        throw new \RuntimeException("Patchwork Failed to delete old patched file at '$patchedPath' (from $corePath) - check permissions?");
+      }
+      else {
+        Civi::log()->notice("Patchwork::deletePatch($corePath) succeeded.");
+      }
+    }
+    else {
+      Civi::log()->info("Patchwork::deletePatch($corePath): no patch to delete.");
+    }
+  }
+  /**
+   * System check.
+   */
+  public function systemCheck(array &$messages) {
+    // Check the patchwork dir exists and is writeable.
+    $patchesDir = $this->getPatchesDir();
+    try {
+      $this->prepareDir();
+    }
+    catch (PatchingFailedException $e) {
+      $messages[] = new \CRM_Utils_Check_Message(
+        'patchwork_missing_patch_dir',
+        ts('The directory at %1 is missing and attempting to create it failed.', [1 => $patchesDir]),
+        ts('Patchwork patches dir missing'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-flag'
+      );
+      return;
+    }
+    if (!is_writeable($patchesDir)) {
+      $messages[] = new \CRM_Utils_Check_Message(
+        'patchwork_patch_dir_unwriteable',
+        ts('The directory at %1 is not writeable', [1 => $patchesDir]),
+        ts('Patchwork patches dir must be writeable.'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-flag'
+      );
+    }
+    // Now check all the files within it are writeable.
+    $dir = new \DirectoryIterator($patchesDir);
+    $errors = [];
+    foreach ($dir as $fileinfo) {
+      if (!$fileinfo->isDot()) {
+        if (!is_writeable($patchesDir . '/' . $fileinfo->getFilename())) {
+          $errors[] = $fileinfo->getFilename();
+        }
+      }
+    }
+    if ($errors) {
+      $messages[] = new \CRM_Utils_Check_Message(
+        'patchwork_patch_unwriteable_files',
+        ts('The files %1 are not writeable in %2', [2 => $patchesDir, 1 => implode(' ', $errors)]),
+        ts('Patchwork patched files are not writeable.'),
+        \Psr\Log\LogLevel::ERROR,
+        'fa-flag'
+      );
+    }
+  }
+}

--- a/Civi/Patchwork.php
+++ b/Civi/Patchwork.php
@@ -16,13 +16,13 @@ class Patchwork {
   /**
    * @var Patchwork Holds singleton.
    */
-  protected Patchwork $singleton;
+  protected static Patchwork $singleton;
 
   /**
    * Main calling point; all exceptions logged as critical messages, but
    * execution will continue.
    */
-  public static function includeOnce(string $corePath) {
+  public function includeOnce(string $corePath) {
     try {
       // Check $corePath is ok and we have what we need to continue.
       $p = new Worker($corePath);
@@ -118,7 +118,7 @@ class Patchwork {
   public function deletePatch(string $corePath) {
     $patchesDir = $this->getPatchesDir();
 
-    $patchedPath = $patchesDir . '/' . sha1($corePath . CIVICRM_SITE_KEY) . '.php';
+    $patchedPath = $patchesDir . '/' . $this->getHashedFilename($corePath);
     if (file_exists($patchedPath)) {
       if (!unlink($patchedPath)) {
         throw new \RuntimeException("Patchwork Failed to delete old patched file at '$patchedPath' (from $corePath) - check permissions?");
@@ -178,5 +178,8 @@ class Patchwork {
         'fa-flag'
       );
     }
+  }
+  public function getHashedFilename(string $corePath) :string {
+    return sha1($corePath . CIVICRM_SITE_KEY) . '.php';
   }
 }

--- a/Civi/Patchwork/CannotIncludeException.php
+++ b/Civi/Patchwork/CannotIncludeException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Civi\Patchwork;
+
+/**
+ * This extension is thrown if patchwork will be unable to provide a file to be
+ * included at all; not even the original.
+ */
+class CannotIncludeException extends \RuntimeException {
+}

--- a/Civi/Patchwork/PatchingFailedException.php
+++ b/Civi/Patchwork/PatchingFailedException.php
@@ -1,0 +1,10 @@
+<?php
+namespace Civi\Patchwork;
+
+/**
+ * This extension is thrown if patchwork fails to apply a patch for some reason.
+ * Typically this will lead to the original file being included.
+ */
+class PatchingFailedException extends \RuntimeException {
+}
+

--- a/Civi/Patchwork/Worker.php
+++ b/Civi/Patchwork/Worker.php
@@ -1,0 +1,194 @@
+<?php
+namespace Civi\Patchwork;
+
+use Civi;
+
+/**
+ * The main doing class.
+ *
+ * outcomes of normal operation:
+ * - orig file not found: do not include anything, log critical
+ * - orig file could not be read; could not be patched: log critical but include original.
+ * - new patch created: log notice; include patched  file.
+ * - existing patch reused: include patched file.
+ * - coding errors: refuse to include anythign. log critical.
+ *
+ */
+class Worker {
+
+  /**
+   * @var string The core filepath being overridden (starts with /)
+   */
+  protected $corePath = '';
+
+  /**
+   * @var string Absolute path to $corePath
+   */
+  protected $originalPath = '';
+
+  /**
+   * @var string Absolute path to patched version.
+   */
+  protected $patchedPath = '';
+
+  /**
+   * @var string The file that should be included, or '' if the original file is not found.
+   */
+  protected $usePatch = '';
+
+  /**
+   * Main calling point; all exceptions logged as critical messages, but
+   * execution will continue.
+   */
+  public static function doInclude(string $corePath) {
+    try {
+      // Check $corePath is ok and we have what we need to continue.
+      $p = new static($corePath);
+      // Make patch as necessary
+      $this->ensurePatchApplied();
+      // If that worked, include the patched version.
+      include_once $p->getPatchedPath();
+    }
+    catch (CannotIncludeException $e) {
+      Civi::log()->critical("Patchwork CannotIncludeException, code may be missing ({$corePath}): " . $e->getMessage());
+    }
+    catch (PatchingFailedException $e) {
+      Civi::log()->critical("Patchwork PatchingFailedException, using original unpatched code ({$corePath}): " . $e->getMessage());
+      include_once $p->getOriginalPath();
+    }
+    catch (\Exception $e) {
+      Civi::log()->critical("Patchwork unhandled exception: " . get_class($e) . " ({$corePath}): " . $e->getMessage());
+      throw $e;
+    }
+  }
+
+  /**
+   * Prepare the directory for the patched files, return the path or throw a PatchingFailedException.
+   */
+  public static function preparePatchworkDir() :string {
+    // Need to create patches dir.
+    // Attempt, but don't abort (i.e. throw exception) if it fails.
+    $patchesDir = static::getPatchworkDir();
+    $outcome = \CRM_Utils_File::createDir($patchesDir, FALSE);
+    if ($outcome === FALSE) {
+      // Creation failed.
+      throw new PatchingFailedException("Patchwork failed to create/prepare the patches directory at '{$patchesDir}'");
+    }
+    // Otherwise (TRUE|NULL), it's fine.
+    return $patchesDir;
+  }
+  /**
+   * Returns the path to the patches dir.
+   */
+  public static function getPatchworkDir() :string {
+    return Civi::paths()->getPath('[civicrm.files]/patchwork/');
+  }
+  /**
+   * Sanity-check the input and calculate the required paths.
+   *
+   * Throws exceptions if it will not be able to run.
+   */
+  public function __construct(string $corePath) {
+
+    // paranoia: check the override for anything unexpected. If there is a case
+    // for anything that doesn't match this regex, please submit an issue/PR.
+    if (!preg_match('@^/[/a-zA-Z0-9_-]+\.php$@', $corePath)) {
+      throw new CannotIncludeException("Dodgy looking override file. Refusing to touch it. This is likely a coding error in an extension trying to use Patchwork. Given: " . json_encode($corePath, JSON_UNESCAPED_SLASHES));
+    }
+
+    $paths = Civi::paths();
+    $this->corePath = $corePath;
+    $this->originalPath = $paths->getPath("[civicrm.root]$corePath");
+    if (!file_exists($this->originalFilePath)) {
+      throw new CannotIncludeException("Can not patch non-existant file '{$this->originalFilePath}'");
+    }
+
+    if (!defined('CIVICRM_SITE_KEY')) {
+      // Without a site key, the hash would be knowable. This could potentially
+      // expose non-public php files to public access (though it shouldn't in a
+      // properly configured environment).
+      throw new PatchingFailedException("Refusing to patch because missing CIVICRM_SITE_KEY could be a security risk.");
+    }
+
+    // Otherwise, looks ok, store the patchedPath now.
+    $this->patchedPath = $paths->getPath(
+      '[civicrm.files]/patchwork/'
+      . sha1($corePath . CIVICRM_SITE_KEY)
+      . '.php');
+  }
+
+  /**
+   * Ensure we have a patched file or throw exception.
+   */
+  public function ensurePatchApplied(bool $force = FALSE) :Worker {
+
+    // Do we need to (re)create the patched file?
+    if ($force) {
+      Civi::log()->info("Patchwork: forcing (re)patch of '{$this->corePath}'");
+    }
+    elseif (!file_exists($this->patchedPath)) {
+      Civi::log()->info("Patchwork: Creating new patched version of '{$this->corePath}'");
+    }
+    elseif (filemtime($this->originalPath) > filemtime($this->patchedPath)) {
+      Civi::log()->info("Patchwork: Updating patched version of '{$this->corePath}'");
+    }
+    else {
+      // Nothing to do, we have an up-to-date patched file.
+      return $this;
+    }
+
+    // Try to patch the file.
+    return $this->createPatchedFile();
+  }
+
+  /**
+   */
+  public function createPatchedFile() :Worker {
+
+    $code = file_get_contents($this->originalPath);
+    if (!$code) {
+      throw new CannotIncludeException("Original file ({$this->originalPath}) has zero size/could not be loaded!");
+    }
+
+    $dummy = NULL;
+    CRM_Utils_Hook::singleton()->invoke(
+      ['override', 'code'], $this->originalPath, $code,
+      $dummy, $dummy, $dummy, $dummy,
+      'patchwork_apply_patch');
+
+    // Save the patched code and if that worked, we'll include that file.
+    if (!$code) {
+      throw new PatchingFailedException("After patching, code was empty.");
+    }
+
+    static::preparePatchworkDir();
+
+    // Prepend a comment to the code.
+    $code = "<?php /** patchwork-patched version of {$this->corePath} */ ?>$code";
+
+    if (file_put_contents($this->patchedPath, $code)) {
+      $file_to_include = $patched_version;
+      Civi::log()->info("patchwork: successfully (re)patched $override", []);
+    }
+    else {
+      throw new PatchingFailedException("Failed to write patch file at {$this->patchedPath}");
+    }
+  }
+
+  /**
+   * Return the aboslute path to the patched file.
+   */
+  public function getPatchedPath() :string {
+    return $this->patchedPath;
+  }
+
+  /**
+   * Return the aboslute path to the original file.
+   */
+  public function getOriginalPath() :string {
+    return $this->originalPath;
+  }
+
+
+}
+

--- a/Civi/Patchwork/Worker.php
+++ b/Civi/Patchwork/Worker.php
@@ -53,8 +53,8 @@ class Worker {
     $paths = Civi::paths();
     $this->corePath = $corePath;
     $this->originalPath = $paths->getPath("[civicrm.root]$corePath");
-    if (!file_exists($this->originalFilePath)) {
-      throw new CannotIncludeException("Can not patch non-existant file '{$this->originalFilePath}'");
+    if (!file_exists($this->originalPath)) {
+      throw new CannotIncludeException("Can not patch non-existant file '{$this->originalPath}'");
     }
 
     if (!defined('CIVICRM_SITE_KEY')) {
@@ -65,10 +65,7 @@ class Worker {
     }
 
     // Otherwise, looks ok, store the patchedPath now.
-    $this->patchedPath = $paths->getPath(
-      '[civicrm.files]/patchwork/'
-      . sha1($corePath . CIVICRM_SITE_KEY)
-      . '.php');
+    $this->patchedPath = $paths->getPath('[civicrm.files]/patchwork/' . Patchwork::singleton()->getHashedFilename($corePath));
   }
 
   /**
@@ -108,7 +105,7 @@ class Worker {
     // Let extensions patch this code.
     $dummy = NULL;
     \CRM_Utils_Hook::singleton()->invoke(
-      ['override', 'code'], $this->originalPath, $code,
+      ['override', 'code'], $this->corePath, $code,
       $dummy, $dummy, $dummy, $dummy,
       'patchwork_apply_patch');
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The easiest way is to delete the patched file in question.
   a patch for that core file. This can be useful in **extension Upgrader
   classes** for example, to ensure your new patch logic is applied.
 
-- Progammatically: call `\Civi\Patchwork::deletePatches()` which will delete
+- Progammatically: call `\Civi\Patchwork::singleton()->deletePatches()` which will delete
   *all* patches. This could feasibly be useful if you were worried about old
   patch files kicking around; say a patched version of something that a
   now-deleted/disabled extension created.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The easiest way is to delete the patched file in question.
 -  Manually: Just delete the files in `[civicrm.files]/patchwork/`
 
 - Progammatically: call
-  `\Civi\Patchwork::deletePatch('/CRM/Mailing/MailStore.php')` which will delete
+  `\Civi\Patchwork::singleton()->deletePatch('/CRM/Mailing/MailStore.php')` which will delete
   a patch for that core file. This can be useful in **extension Upgrader
   classes** for example, to ensure your new patch logic is applied.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ git clone https://github.com/artfulrobot/patchworkdemo.git
 cv en patchworkdemo
 ```
 
-### License
+## License
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
+
+## Change log
+
+### 1.3
+
+- Big refactor
+
+- Add phpunit tests (including patchworktest extension). Note: patchworktest extension should **never** be installed on a site. It's just for use by phpunit.
+
+- Add programmatic ways to delete patched files, e.g. useful if your extension has updated the patch it applies  (see "How do I manually recreate my patched files" above)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ solves) these problems.
 
 ## How to use it
 
-The [mailstorepermissions
-extension](https://github.com/artfulrobot/mailstorepermissions)
+The [mailstorepermissions extension](https://github.com/artfulrobot/mailstorepermissions)
 shows a real world example.
 
 1. It includes a core override for the file which contains this line of code:

--- a/README.md
+++ b/README.md
@@ -29,11 +29,16 @@ whatever else you want to do.
 
 If you can't patch it you can either:
 
-- throw an exception
+- throw an exception. It is advised to throw one of:
 
-- set the `$code` to something falsy.
+   - `Civi\Patchwork\CannotIncludeException` if you would like the outcome to
+     be that no code (not even the original) gets used.
 
-In which case the original core file will be used (and an error logged).
+   - `Civi\Patchwork\PatchingFailedException` if you would like the outcome to
+     be that the original code gets used.
+
+- set the `$code` to something falsy in which case the original core file will
+  be used (and an error logged).
 
 ## Won't this slow my site down - all this patching?
 
@@ -47,8 +52,24 @@ gets recreated.
 
 ## How do I manually recreate my patched files?
 
-Just delete the files in `[civicrm.files]/patchwork/`
+The easiest way is to delete the patched file in question.
 
+-  Manually: Just delete the files in `[civicrm.files]/patchwork/`
+
+- Progammatically: call
+  `\Civi\Patchwork::deletePatch('/CRM/Mailing/MailStore.php')` which will delete
+  a patch for that core file. This can be useful in **extension Upgrader
+  classes** for example, to ensure your new patch logic is applied.
+
+- Progammatically: call `\Civi\Patchwork::deletePatches()` which will delete
+  *all* patches. This could feasibly be useful if you were worried about old
+  patch files kicking around; say a patched version of something that a
+  now-deleted/disabled extension created.
+
+Deleting patched files should be reasonably safe to do at any time; they will
+just get recreated on their next use. There is a slight timing risk if the
+deletion happens after one process created it and before it calls `include()`
+on it, but we're talking microseconds of risk here.
 
 ## Doesn't this leave the patched files vulnerable to download?
 

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-12-16</releaseDate>
-  <version>1.2</version>
+  <version>1.3</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.0</ver>
@@ -23,4 +23,7 @@
   <civix>
     <namespace>CRM/Patchwork</namespace>
   </civix>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
 </extension>

--- a/patchworktest/CRM/Activity/BAO/ICalendar.php
+++ b/patchworktest/CRM/Activity/BAO/ICalendar.php
@@ -1,0 +1,3 @@
+<?php
+Civi::log()->info('artfulrobot: test NEW ICalendar');
+patchwork__patch_file('/CRM/Activity/BAO/ICalendar.php');

--- a/patchworktest/LICENSE.txt
+++ b/patchworktest/LICENSE.txt
@@ -1,0 +1,667 @@
+Package: patchworktest
+Copyright (C) 2022, FIXME <FIXME>
+Licensed under the GNU Affero Public License 3.0 (below).
+
+-------------------------------------------------------------------------------
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/patchworktest/README.md
+++ b/patchworktest/README.md
@@ -1,0 +1,4 @@
+# patchworktest
+
+This is only used by the patchwork extension's phpunit tests. Do NOT install it on your site (it will break things).
+

--- a/patchworktest/info.xml
+++ b/patchworktest/info.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<extension key="patchworktest" type="module">
+  <file>patchworktest</file>
+  <name>Patchwork Test</name>
+  <description>This should NOT be enabled on your site; it WILL break functionality if you do enable it! It is only used for running the phpunit tests of the patchwork extension in a test environment.</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>Rich Lott / Artful Robot</author>
+    <email>code.commits@artfulrobot.uk</email>
+  </maintainer>
+  <urls>
+    <url desc="Main Extension Page">https://github.com/artfulrobot/patchwork</url>
+    <url desc="Documentation">https://github.com/artfulrobot/patchwork</url>
+    <url desc="Support">https://github.com/artfulrobot/patchwork</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>2022-04-19</releaseDate>
+  <version>1.0</version>
+  <develStage>alpha</develStage>
+  <compatibility>
+    <ver>5.0</ver>
+  </compatibility>
+  <comments>This is only used by phpunit and should not be enabled on normal site.</comments>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/Patchworktest</namespace>
+  </civix>
+</extension>

--- a/patchworktest/patchworktest.civix.php
+++ b/patchworktest/patchworktest.civix.php
@@ -1,0 +1,477 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Patchworktest_ExtensionUtil {
+  const SHORT_NAME = 'patchworktest';
+  const LONG_NAME = 'patchworktest';
+  const CLASS_PREFIX = 'CRM_Patchworktest';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Patchworktest_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _patchworktest_civix_civicrm_config(&$config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $template =& CRM_Core_Smarty::singleton();
+
+  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extDir = $extRoot . 'templates';
+
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
+  }
+  else {
+    $template->template_dir = [$extDir, $template->template_dir];
+  }
+
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_xmlMenu().
+ *
+ * @param $files array(string)
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
+ */
+function _patchworktest_civix_civicrm_xmlMenu(&$files) {
+  foreach (_patchworktest_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
+    $files[] = $file;
+  }
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _patchworktest_civix_civicrm_install() {
+  _patchworktest_civix_civicrm_config();
+  if ($upgrader = _patchworktest_civix_upgrader()) {
+    $upgrader->onInstall();
+  }
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function _patchworktest_civix_civicrm_postInstall() {
+  _patchworktest_civix_civicrm_config();
+  if ($upgrader = _patchworktest_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
+      $upgrader->onPostInstall();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
+ */
+function _patchworktest_civix_civicrm_uninstall() {
+  _patchworktest_civix_civicrm_config();
+  if ($upgrader = _patchworktest_civix_upgrader()) {
+    $upgrader->onUninstall();
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _patchworktest_civix_civicrm_enable() {
+  _patchworktest_civix_civicrm_config();
+  if ($upgrader = _patchworktest_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onEnable'])) {
+      $upgrader->onEnable();
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_disable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ * @return mixed
+ */
+function _patchworktest_civix_civicrm_disable() {
+  _patchworktest_civix_civicrm_config();
+  if ($upgrader = _patchworktest_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onDisable'])) {
+      $upgrader->onDisable();
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_upgrade().
+ *
+ * @param $op string, the type of operation being performed; 'check' or 'enqueue'
+ * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
+ *
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
+ */
+function _patchworktest_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  if ($upgrader = _patchworktest_civix_upgrader()) {
+    return $upgrader->onUpgrade($op, $queue);
+  }
+}
+
+/**
+ * @return CRM_Patchworktest_Upgrader
+ */
+function _patchworktest_civix_upgrader() {
+  if (!file_exists(__DIR__ . '/CRM/Patchworktest/Upgrader.php')) {
+    return NULL;
+  }
+  else {
+    return CRM_Patchworktest_Upgrader_Base::instance();
+  }
+}
+
+/**
+ * Search directory tree for files which match a glob pattern.
+ *
+ * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
+ * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ *
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
+ */
+function _patchworktest_civix_find_files($dir, $pattern) {
+  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
+    return CRM_Utils_File::findFiles($dir, $pattern);
+  }
+
+  $todos = [$dir];
+  $result = [];
+  while (!empty($todos)) {
+    $subdir = array_shift($todos);
+    foreach (_patchworktest_civix_glob("$subdir/$pattern") as $match) {
+      if (!is_dir($match)) {
+        $result[] = $match;
+      }
+    }
+    if ($dh = opendir($subdir)) {
+      while (FALSE !== ($entry = readdir($dh))) {
+        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
+        if ($entry[0] == '.') {
+        }
+        elseif (is_dir($path)) {
+          $todos[] = $path;
+        }
+      }
+      closedir($dh);
+    }
+  }
+  return $result;
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_managed().
+ *
+ * Find any *.mgd.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
+ */
+function _patchworktest_civix_civicrm_managed(&$entities) {
+  $mgdFiles = _patchworktest_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
+  foreach ($mgdFiles as $file) {
+    $es = include $file;
+    foreach ($es as $e) {
+      if (empty($e['module'])) {
+        $e['module'] = E::LONG_NAME;
+      }
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
+      }
+      $entities[] = $e;
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_caseTypes().
+ *
+ * Find any and return any files matching "xml/case/*.xml"
+ *
+ * Note: This hook only runs in CiviCRM 4.4+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
+ */
+function _patchworktest_civix_civicrm_caseTypes(&$caseTypes) {
+  if (!is_dir(__DIR__ . '/xml/case')) {
+    return;
+  }
+
+  foreach (_patchworktest_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+    $name = preg_replace('/\.xml$/', '', basename($file));
+    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
+      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
+      throw new CRM_Core_Exception($errorMessage);
+    }
+    $caseTypes[$name] = [
+      'module' => E::LONG_NAME,
+      'name' => $name,
+      'file' => $file,
+    ];
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
+ *
+ * Note: This hook only runs in CiviCRM 4.5+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+ */
+function _patchworktest_civix_civicrm_angularModules(&$angularModules) {
+  if (!is_dir(__DIR__ . '/ang')) {
+    return;
+  }
+
+  $files = _patchworktest_civix_glob(__DIR__ . '/ang/*.ang.php');
+  foreach ($files as $file) {
+    $name = preg_replace(':\.ang\.php$:', '', basename($file));
+    $module = include $file;
+    if (empty($module['ext'])) {
+      $module['ext'] = E::LONG_NAME;
+    }
+    $angularModules[$name] = $module;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _patchworktest_civix_civicrm_themes(&$themes) {
+  $files = _patchworktest_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
+  }
+}
+
+/**
+ * Glob wrapper which is guaranteed to return an array.
+ *
+ * The documentation for glob() says, "On some systems it is impossible to
+ * distinguish between empty match and an error." Anecdotally, the return
+ * result for an empty match is sometimes array() and sometimes FALSE.
+ * This wrapper provides consistency.
+ *
+ * @link http://php.net/glob
+ * @param string $pattern
+ *
+ * @return array
+ */
+function _patchworktest_civix_glob($pattern) {
+  $result = glob($pattern);
+  return is_array($result) ? $result : [];
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _patchworktest_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label'      => CRM_Utils_Array::value('name', $item),
+        'active'     => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _patchworktest_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _patchworktest_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _patchworktest_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _patchworktest_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _patchworktest_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _patchworktest_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _patchworktest_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_alterSettingsFolders().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
+ */
+function _patchworktest_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+    $metaDataFolders[] = $settingsDir;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function _patchworktest_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, []);
+}

--- a/patchworktest/patchworktest.php
+++ b/patchworktest/patchworktest.php
@@ -1,0 +1,159 @@
+<?php
+
+require_once 'patchworktest.civix.php';
+// phpcs:disable
+use CRM_Patchworktest_ExtensionUtil as E;
+// phpcs:enable
+
+/**
+ * Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
+ */
+function patchworktest_civicrm_config(&$config) {
+  _patchworktest_civix_civicrm_config($config);
+}
+
+/**
+ * Implements hook_civicrm_xmlMenu().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
+ */
+function patchworktest_civicrm_xmlMenu(&$files) {
+  _patchworktest_civix_civicrm_xmlMenu($files);
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function patchworktest_civicrm_install() {
+  _patchworktest_civix_civicrm_install();
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function patchworktest_civicrm_postInstall() {
+  _patchworktest_civix_civicrm_postInstall();
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
+ */
+function patchworktest_civicrm_uninstall() {
+  _patchworktest_civix_civicrm_uninstall();
+}
+
+/**
+ * Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function patchworktest_civicrm_enable() {
+  _patchworktest_civix_civicrm_enable();
+}
+
+/**
+ * Implements hook_civicrm_disable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ */
+function patchworktest_civicrm_disable() {
+  _patchworktest_civix_civicrm_disable();
+}
+
+/**
+ * Implements hook_civicrm_upgrade().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
+ */
+function patchworktest_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  return _patchworktest_civix_civicrm_upgrade($op, $queue);
+}
+
+/**
+ * Implements hook_civicrm_managed().
+ *
+ * Generate a list of entities to create/deactivate/delete when this module
+ * is installed, disabled, uninstalled.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
+ */
+function patchworktest_civicrm_managed(&$entities) {
+  _patchworktest_civix_civicrm_managed($entities);
+}
+
+/**
+ * Implements hook_civicrm_caseTypes().
+ *
+ * Generate a list of case-types.
+ *
+ * Note: This hook only runs in CiviCRM 4.4+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
+ */
+function patchworktest_civicrm_caseTypes(&$caseTypes) {
+  _patchworktest_civix_civicrm_caseTypes($caseTypes);
+}
+
+/**
+ * Implements hook_civicrm_angularModules().
+ *
+ * Generate a list of Angular modules.
+ *
+ * Note: This hook only runs in CiviCRM 4.5+. It may
+ * use features only available in v4.6+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+ */
+function patchworktest_civicrm_angularModules(&$angularModules) {
+  _patchworktest_civix_civicrm_angularModules($angularModules);
+}
+
+/**
+ * Implements hook_civicrm_alterSettingsFolders().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
+ */
+function patchworktest_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  _patchworktest_civix_civicrm_alterSettingsFolders($metaDataFolders);
+}
+
+/**
+ * Implements hook_civicrm_entityTypes().
+ *
+ * Declare entity types provided by this module.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function patchworktest_civicrm_entityTypes(&$entityTypes) {
+  _patchworktest_civix_civicrm_entityTypes($entityTypes);
+}
+
+/**
+ * Implements hook_civicrm_thems().
+ */
+function patchworktest_civicrm_themes(&$themes) {
+  _patchworktest_civix_civicrm_themes($themes);
+}
+
+
+/**
+ * Dummy implementation.
+ */
+function patchworktest_patchwork_apply_patch($corePath, &$code) {
+  if ($corePath === '/CRM/Activity/BAO/ICalendar.php') {
+    // Append a global declaration that would run when the patched file is included.
+    $code .= "\n\$GLOBALS['patchworktest_patchwork_apply_patch']++;// patchworktest_version: " . $GLOBALS['patchworktest_version'] . "\n";
+  }
+  else {
+    $code = FALSE;
+  }
+}
+

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/phpunit/Civi/PatchworkTest.php
+++ b/tests/phpunit/Civi/PatchworkTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use CRM_Patchwork_ExtensionUtil as E;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * FIXME - Add test description.
+ *
+ * Tips:
+ *  - With HookInterface, you may implement CiviCRM hooks directly in the test class.
+ *    Simply create corresponding functions (e.g. "hook_civicrm_post(...)" or similar).
+ *  - With TransactionalInterface, any data changes made by setUp() or test****() functions will
+ *    rollback automatically -- as long as you don't manipulate schema or truncate tables.
+ *    If this test needs to manipulate schema or truncate tables, then either:
+ *       a. Do all that using setupHeadless() and Civi\Test.
+ *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
+ *
+ * @group headless
+ */
+class Civi_PatchworkTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+    // See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+    return \Civi\Test::headless()
+      ->install(['patchwork', 'patchworktest'])
+      ->apply();
+  }
+
+  public function setUp() {
+    parent::setUp();
+    Civi\Patchwork::singleton()->deletePatches();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   *
+   */
+  public function testBasicOperation() {
+    $GLOBALS['patchworktest_patchwork_apply_patch'] = 0;
+    $GLOBALS['patchworktest_version'] = 1;
+
+    // Cause Civi to load this class file - we hope it loads the patched version.
+    include_once 'CRM/Activity/BAO/ICalendar.php';
+    // The patched version sets a global var, so we can test if that ran.
+    $this->assertEquals(1, $GLOBALS['patchworktest_patchwork_apply_patch'], "Expected the patched file to have been run but it appears not to have been.");
+
+    // Check the file is where we expect it to be.
+    $p = \Civi\Patchwork::singleton();
+    $patchFile = $p->getPatchesDir() . '/' . $p->getHashedFilename('/CRM/Activity/BAO/ICalendar.php');
+    $this->assertFileExists($patchFile);
+
+    // Check the file contains 'patchworktest_version: 1'
+    $src = file_get_contents($patchFile);
+    $this->assertStringContainsString('patchworktest_version: 1', $src, "Patched file does not contain expected 'patchworktest_version: 1'");
+
+    // Check we can delete the file
+    $p->deletePatch('/CRM/Activity/BAO/ICalendar.php');
+    $this->assertFileNotExists($p->getPatchesDir() . '/' . $p->getHashedFilename('/CRM/Activity/BAO/ICalendar.php'));
+
+    // Check it would be recreated by ensurePatchApplied()
+    $w = new Civi\Patchwork\Worker('/CRM/Activity/BAO/ICalendar.php');
+    $w->ensurePatchApplied();
+    $this->assertFileExists($p->getPatchesDir() . '/' . $p->getHashedFilename('/CRM/Activity/BAO/ICalendar.php'));
+
+    // Check deletePatches deletes all patches (but leaves other files)
+    // Create a dummy other patch with 40 char filename (like SHA1)
+    touch($p->getPatchesDir() . '/0123456789012345678901234567890123456789.php');
+    // Create some other file that does not match.
+    touch($p->getPatchesDir() . '/something-else.txt');
+    $p->deletePatches();
+    $this->assertFileExists($p->getPatchesDir() . '/something-else.txt');
+    $this->assertFileNotExists($p->getPatchesDir() . '/0123456789012345678901234567890123456789.php');
+    $this->assertFileNotExists($p->getPatchesDir() . '/' . $p->getHashedFilename('/CRM/Activity/BAO/ICalendar.php'));
+    // Clean up
+    unlink($p->getPatchesDir() . '/something-else.txt');
+
+    // Now this time...repeat this:
+    $w->ensurePatchApplied();
+    $src = file_get_contents($patchFile);
+    $this->assertStringContainsString('patchworktest_version: 1', $src, "Patched file does not contain expected 'patchworktest_version: 1'");
+    // Calling ensurePatchApplied again should not result in a change, since nothing has changed.
+    $GLOBALS['patchworktest_version'] = 2;
+    $w->ensurePatchApplied();
+    $src = file_get_contents($patchFile);
+    $this->assertGreaterThan(0, strpos($src, 'patchworktest_version: 1'), "Patched file does not contain expected 'patchworktest_version: 1'");
+    // Change the mtime on our patch file so it's older than that of the core file.
+    $coreMtime = filemtime($w->getOriginalPath());
+    touch($patchFile, $coreMtime - 60);
+    $w->ensurePatchApplied();
+    $src = file_get_contents($patchFile);
+    $this->assertGreaterThan(0, strpos($src, 'patchworktest_version: 2'), "Patched file does not contain expected 'patchworktest_version: 2'");
+
+    // Check we can force it.
+    $GLOBALS['patchworktest_version'] = 3;
+    $w->ensurePatchApplied(TRUE);
+    $src = file_get_contents($patchFile);
+    $this->assertGreaterThan(0, strpos($src, 'patchworktest_version: 3'), "Patched file does not contain expected 'patchworktest_version: 3'");
+
+    // Cleanup.
+    $p->deletePatches();
+  }
+
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,63 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
This is a preferred approach over https://github.com/artfulrobot/patchwork/pull/2

From README:

- Progammatically: call  
  `\Civi\Patchwork::deletePatch('/CRM/Mailing/MailStore.php')` which will delete
  a patch for that core file. This can be useful in **extension Upgrader
  classes** for example, to ensure your new patch logic is applied.
                                                                                                                                                                                              
- Progammatically: call `\Civi\Patchwork::deletePatches()` which will delete 
  *all* patches. This could feasibly be useful if you were worried about old 
  patch files kicking around; say a patched version of something that a 
  now-deleted/disabled extension created.

## Example use: you maintain an extension that patches a file and you have a new patching method

Before this PR, patchwork would not know to recretate the patch.

With this PR, your extension can implement the Upgrader class pattern and include one of the calls above to ensure that the files get re-patched.

During development, you can add calls to that code somewhere in an early-firing hook, so it's repatched every runtime.

@mattwire 